### PR TITLE
kubernetes networks hw3

### DIFF
--- a/kubernetes-networks/deployment.yaml
+++ b/kubernetes-networks/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homework-deployment
+  namespace: homework
+  labels:
+    app: nginx-homework
+spec:
+  replicas: 3
+
+  selector:
+    matchLabels:
+      app: nginx-homework-pod
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+
+  template:
+    metadata:
+      labels:
+        app: nginx-homework-pod
+    spec:
+      nodeSelector:
+        homework: "true"
+
+      initContainers:
+        - name: init-download
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - "wget -O /init-data/index.html http://example.com && chmod +r /init-data/index.html"
+          volumeMounts:
+            - name: shared-html-data
+              mountPath: /init-data
+
+      containers:
+        - name: web
+          #image: nginx:1.25.4-alpine
+          image: nginx:latest
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: shared-html-data
+              mountPath: /usr/share/nginx/html
+          lifecycle:
+            preStop:
+              exec:
+                command: ["rm", "-f", "/usr/share/nginx/html/index.html"]
+
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+
+      volumes:
+        - name: shared-html-data
+          emptyDir: {}

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: homework-ingress
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /index.html
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: homework.otus
+    http:
+      paths:
+      - path: /homepage
+        pathType: Exact
+        backend:
+          service:
+            name: homework-service
+            port:
+              number: 80
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: homework-service
+            port:
+              number: 80

--- a/kubernetes-networks/namespace.yaml
+++ b/kubernetes-networks/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-networks/service.yaml
+++ b/kubernetes-networks/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homework-service
+  namespace: homework
+  labels:
+    app: nginx-homework
+spec:
+  type: ClusterIP
+  selector:
+    app: nginx-homework-pod
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80


### PR DESCRIPTION
# Выполнено ДЗ № 3 - Сетевое взаимодействие Pod, Сервисы, Ingress

- [x] Основное ДЗ (изменение readinessProbe, Service ClusterIP, Ingress для homework.otus)
- [x] Задание со * (Ingress rewrite: /homepage отдает содержимое /index.html)

## В процессе сделано:
- Создана директория `kubernetes-networks` с файлами `namespace.yaml`, `deployment.yaml`, `service.yaml`, `ingress.yaml`.
- `deployment.yaml`: readinessProbe изменена на `httpGet` (порт 80), `mountPath` для Nginx изменен на `/usr/share/nginx/html`.
- `service.yaml`: создан Service `homework-service` типа `ClusterIP`.
- `ingress.yaml`: настроен Ingress `homework-ingress` для хоста `homework.otus`, направляющий трафик на `homework-service`.
  - (Для задания со *) Добавлены правила/аннотации для rewrite пути `/homepage` на `/index.html`.
- Установлен Nginx Ingress Controller в Minikube.

## Как запустить проект:
1. Запустить Minikube: `minikube start --driver=docker`
2. Включить Ingress addon: `minikube addons enable ingress`
3. Добавить метку на ноду (для `nodeSelector` из ДЗ№2): `kubectl label node minikube homework=true`
4. Применить манифесты: `kubectl apply -f kubernetes-networks/`
5. **В отдельном терминале запустить:** `minikube tunnel` (и оставить его работать, напрямую не сработало делал в wsl) 
6. Обновить файл `/etc/hosts` : `127.0.0.1 homework.otus`
  
## Как проверить работоспособность:
- Статус ресурсов: `kubectl get deployment,service,ingress,endpoints -n homework`.
- Доступ к основному пути: `curl http://homework.otus/index.html` (или `http://homework.otus/`).
- (Для задания со *) Доступ через rewrite: `curl http://homework.otus/homepage`.
  (Все три должны возвращать содержимое `example.com`).

## PR checklist:
 - [x] Выставлен label с темой домашнего задания.
