### PR TITLE
Implement K8s Volumes, PVC, SC and ConfigMap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Dependencies
+node_modules/
+__pycache__/

--- a/kubernetes-volumes/cm.yaml
+++ b/kubernetes-volumes/cm.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kuber-cm
+  namespace: homework
+data:
+  dbuser: "admin"
+  dbpass: "qwerty"
+  dbconfig: |
+    dbuser: admin
+    dbpass: qwerty

--- a/kubernetes-volumes/deployment.yaml
+++ b/kubernetes-volumes/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homework-deployment
+  namespace: homework
+  labels:
+    app: nginx-homework
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx-homework-pod
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: nginx-homework-pod
+    spec:
+#      nodeSelector:
+#        homework: "true"
+
+      initContainers:
+        - name: init-download
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - "wget -O /mnt/data/index.html http://example.com && chmod +r /mnt/data/index.html"
+          volumeMounts:
+            - name: persistent-storage
+              mountPath: /mnt/data
+
+      containers:
+        - name: web
+          image: nginx:latest
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: persistent-storage
+              mountPath: /usr/share/nginx/html
+            - name: config-volume
+              mountPath: /homework/conf
+              readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command: ["echo", "PreStop hook: Not removing index.html from PVC"]
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+
+      volumes:
+        - name: persistent-storage
+          persistentVolumeClaim:
+            claimName: kuber-pvc
+
+        - name: config-volume
+          configMap:
+            name: kuber-cm
+            items:
+              - key: "dbuser"
+                path: "file"

--- a/kubernetes-volumes/namespace.yaml
+++ b/kubernetes-volumes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-volumes/pvc.yaml
+++ b/kubernetes-volumes/pvc.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: kuber-pvc
+  namespace: homework
+spec:
+  storageClassName: "custom"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes-volumes/sc.yaml
+++ b/kubernetes-volumes/sc.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: custom
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Retain
+volumeBindingMode: Immediate


### PR DESCRIPTION
# Выполнено ДЗ № [Номер ДЗ] - Volumes, StorageClass, PV, PVC, ConfigMap

- [x] Основное ДЗ (PVC со standard SC, ConfigMap, монтирование в Deployment)
- [x] Задание со * (Кастомный StorageClass 'custom' с Retain, PVC использует 'custom')

## В процессе сделано:
- Создана директория `kubernetes-volumes` и в нее добавлены/модифицированы все необходимые манифесты.
- Создан `pvc.yaml` для запроса персистентного хранилища (1Gi, RWO) через кастомный `StorageClass "custom"`.
- Создан `sc.yaml`, описывающий `StorageClass "custom"` с `provisioner: k8s.io/minikube-hostpath` и `reclaimPolicy: Retain`.
- Создан `cm.yaml`, описывающий `ConfigMap "kuber-cm"` с конфигурационными данными.
- Модифицирован `deployment.yaml`:
    - Том `emptyDir` заменен на `PersistentVolumeClaim "kuber-pvc"` для хранения `index.html`.
    - Добавлено монтирование `ConfigMap "kuber-cm"` в директорию `/homework/conf`, где ключ `dbuser` представлен как файл `file`.
    - (Для отладки) Убран `nodeSelector`, который вызывал проблемы с планированием подов.

## Как запустить проект:
1. Запустить Minikube: `minikube start --driver=docker`
2. Применить манифесты из папки `kubernetes-volumes` по порядку:
   `kubectl apply -f kubernetes-volumes/namespace.yaml`
   `kubectl apply -f kubernetes-volumes/cm.yaml`
   `kubectl apply -f kubernetes-volumes/sc.yaml`
   `kubectl apply -f kubernetes-volumes/pvc.yaml`
   `kubectl apply -f kubernetes-volumes/deployment.yaml`

## Как проверить работоспособность:
- Статус ресурсов: `kubectl get sc,pvc,cm,deployment,pods -n homework` (ожидается, что PVC `Bound`, поды `Running 1/1`).
- Проверка смонтированного PVC: `kubectl exec -it <pod_name> -n homework -- cat /usr/share/nginx/html/index.html`.
- Проверка смонтированного ConfigMap: `kubectl exec -it <pod_name> -n homework -- cat /homework/conf/file`.
- **Проверка персистентности:**
  1. `kubectl delete deployment homework-deployment -n homework`
  2. Дождаться удаления подов.
  3. `kubectl get pvc -n homework` (должен остаться `Bound`).
  4. `kubectl apply -f kubernetes-volumes/deployment.yaml`
  5. Дождаться запуска новых подов.
  6. `kubectl exec -it <new_pod_name> -n homework -- ls -l /usr/share/nginx/html/` (файл `index.html` должен присутствовать).

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
 - [x] PR не будет смерджен самостоятельно.