### PR TITLE
Kubernetes RBAC 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ Thumbs.db
 # Dependencies
 node_modules/
 __pycache__/
+
+token
+cd-kubeconfig.yaml
+homework-cd-config.yaml

--- a/kubernetes-security/cd-rb.yaml
+++ b/kubernetes-security/cd-rb.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cd-admin-binding
+  namespace: homework
+subjects:
+- kind: ServiceAccount
+  name: cd
+  namespace: homework
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-security/cd-sa.yaml
+++ b/kubernetes-security/cd-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cd
+  namespace: homework

--- a/kubernetes-security/cm.yaml
+++ b/kubernetes-security/cm.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kuber-cm
+  namespace: homework
+data:
+  dbuser: "admin"
+  dbpass: "qwerty"
+  dbconfig: |
+    dbuser: admin
+    dbpass: qwerty

--- a/kubernetes-security/deployment.yaml
+++ b/kubernetes-security/deployment.yaml
@@ -1,0 +1,149 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homework-deployment
+  namespace: homework
+  labels:
+    app: nginx-homework
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx-homework-pod
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        app: nginx-homework-pod
+    spec:
+      serviceAccountName: monitoring
+      nodeSelector:
+        homework: "true"
+
+      initContainers:
+        - name: init-download
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - "wget -O /mnt/data/index.html http://example.com && chmod +r /mnt/data/index.html"
+          volumeMounts:
+            - name: persistent-storage
+              mountPath: /mnt/data
+
+        - name: init-metrics
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              echo "Fetching metrics from Kubernetes API..."
+              
+              TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+              CA_CERT=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              
+              echo "Testing different metrics endpoints..."
+              
+              SUCCESS=false
+              
+              if wget --header="Authorization: Bearer $TOKEN" \
+                      --ca-certificate="$CA_CERT" \
+                      -O /tmp/metrics_test.html \
+                      https://kubernetes.default.svc.cluster.local/metrics 2>/dev/null; then
+                cp /tmp/metrics_test.html /mnt/data/metrics.html
+                SUCCESS=true
+                echo "Success: /metrics endpoint"
+              fi
+              
+              if [ "$SUCCESS" = false ]; then
+                if wget --header="Authorization: Bearer $TOKEN" \
+                        --no-check-certificate \
+                        -O /tmp/metrics_test.html \
+                        https://kubernetes.default.svc.cluster.local/metrics 2>/dev/null; then
+                  cp /tmp/metrics_test.html /mnt/data/metrics.html
+                  SUCCESS=true
+                  echo "Success: /metrics endpoint (no SSL verify)"
+                fi
+              fi
+              
+              if [ "$SUCCESS" = false ]; then
+                cat > /mnt/data/metrics.html << 'EOF'
+              <!DOCTYPE html>
+              <html>
+              <head><title>Kubernetes Metrics</title></head>
+              <body>
+                <h1>Kubernetes Metrics Diagnostic</h1>
+                <h2>ServiceAccount Info:</h2>
+                <p><strong>Namespace:</strong> homework</p>
+                <p><strong>ServiceAccount:</strong> monitoring</p>
+                
+                <h2>Attempted Endpoints:</h2>
+                <ul>
+                  <li>https://kubernetes.default.svc.cluster.local/metrics</li>
+                  <li>Token authentication: ✅ Available</li>
+                  <li>CA Certificate: ✅ Available</li>
+                </ul>
+                
+                <h2>Possible Issues:</h2>
+                <ul>
+                  <li>ClusterRole permissions for /metrics endpoint</li>
+                  <li>API server metrics not exposed on /metrics</li>
+                  <li>Network connectivity to API server</li>
+                </ul>
+                
+                <h2>Token Info:</h2>
+                <p>Token length: $(wc -c < /var/run/secrets/kubernetes.io/serviceaccount/token) characters</p>
+                
+                <p><em>Generated: $(date)</em></p>
+              </body>
+              </html>
+              EOF
+                echo "Created diagnostic page"
+              fi
+              
+              chmod +r /mnt/data/metrics.html
+              echo "Metrics processing completed"
+          volumeMounts:
+            - name: persistent-storage
+              mountPath: /mnt/data
+
+      containers:
+        - name: web
+          image: nginx:latest
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: persistent-storage
+              mountPath: /usr/share/nginx/html
+            - name: config-volume
+              mountPath: /homework/conf
+              readOnly: true
+          lifecycle:
+            preStop:
+              exec:
+                command: ["echo", "PreStop hook: Not removing index.html from PVC"]
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+
+      volumes:
+        - name: persistent-storage
+          persistentVolumeClaim:
+            claimName: kuber-pvc
+
+        - name: config-volume
+          configMap:
+            name: kuber-cm
+            items:
+              - key: "dbuser"
+                path: "file"

--- a/kubernetes-security/monitoring-cr.yaml
+++ b/kubernetes-security/monitoring-cr.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metrics-reader
+rules:
+- nonResourceURLs: ["/metrics"]
+  verbs: ["get"]
+- nonResourceURLs: ["/metrics/*"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["nodes/metrics", "pods/metrics"]
+  verbs: ["get", "list"]

--- a/kubernetes-security/monitoring-crb.yaml
+++ b/kubernetes-security/monitoring-crb.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: monitoring-metrics-reader
+subjects:
+- kind: ServiceAccount
+  name: monitoring
+  namespace: homework
+roleRef:
+  kind: ClusterRole
+  name: metrics-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-security/monitoring-sa.yaml
+++ b/kubernetes-security/monitoring-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: monitoring
+  namespace: homework

--- a/kubernetes-security/pvc.yaml
+++ b/kubernetes-security/pvc.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: kuber-pvc
+  namespace: homework
+spec:
+  storageClassName: "standard"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes-security/sc.yaml
+++ b/kubernetes-security/sc.yaml
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: custom
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Retain
+volumeBindingMode: Immediate

--- a/kubernetes-security/service.yaml
+++ b/kubernetes-security/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homework-service
+  namespace: homework
+  labels:
+    app: nginx-homework
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      nodePort: 30080
+  selector:
+    app: nginx-homework-pod


### PR DESCRIPTION
# Выполнено ДЗ № 5 - Настройка сервисных аккаунтов 

- [x] Основное ДЗ (SA, RBAC)
- [x] Задание со * (Реализована механика получения метрик)

## В процессе сделано:
- **RBAC:**
    - Созданы ServiceAccount `monitoring` и `cd`.
    - Для SA `monitoring` настроены права на чтение эндпоинта `/metrics` через `ClusterRole` и `ClusterRoleBinding`.
    - Для SA `cd` настроены права `admin` в рамках namespace `homework` через `RoleBinding`.
- **Volumes:**
    - `Deployment` модифицирован для использования `PersistentVolumeClaim` для хранения `index.html`.
    - `Deployment` модифицирован для монтирования `ConfigMap` для предоставления конфигурации в виде файла `/homework/conf/file`.
- **Задание со звездочкой:**
    - В `Deployment` добавлен `init-container` (`init-metrics`), который от имени SA `monitoring` пытается получить метрики кластера с эндпоинта `/metrics`.
    - Реализована логика: если запрос к `/metrics` успешен, результат сохраняется в `metrics.html`. Если запрос завершается ошибкой (например, из-за недостатка прав), то создается диагностическая HTML-страница с информацией об ошибке, которая также сохраняется в `metrics.html`.
    - Основной контейнер Nginx настроен так, чтобы отдавать этот `metrics.html` по запросу.

## Как запустить проект:
1. Запустить Minikube: `minikube start`
2. (Если требуется для `nodeSelector`) Добавить метку на ноду: `kubectl label node minikube homework=true`
3. Применить все манифесты из папки `kubernetes-security`: `kubectl apply -f kubernetes-security/` (может потребоваться применить `pvc.yaml` и `deployment.yaml` после того, как `StorageClass` будет готов).

## Как проверить работоспособность:
- **Проверка основных ресурсов:**
  `kubectl get sa,pvc,cm,pods -n homework` (убедиться, что все создано и поды `READY 1/1`).
- **Проверка прав RBAC (через `kubectl auth can-i`):**
  `kubectl auth can-i get pods -n homework --as=system:serviceaccount:homework:cd` (ожидается: yes)
  `kubectl auth can-i get pods -n kube-system --as=system:serviceaccount:homework:cd` (ожидается: no)
  `kubectl auth can-i get /metrics --as=system:serviceaccount:homework:monitoring` (ожидается: yes)
- **Проверка задания со звездочкой (доступ к файлу метрик):**
  - Запустить `port-forward` в отдельном терминале: `kubectl port-forward service/homework-service 8080:80 -n homework`
  - В другом терминале выполнить: `curl http://localhost:8080/metrics.html`
  - **Ожидаемый результат:** Будет показана либо HTML-страница с метриками, либо диагностическая HTML-страница, сообщающая о том, что получить метрики не удалось.

## PR checklist:
 - [x] Выставлен label с темой домашнего задания (если применимо).
 - [x] PR не будет смержен самостоятельно.