### PR TITLE
feat(homework): Kubernetes monitoring with Prometheus operator

### DIFF
--- a/kubernetes-monitoring/Dockerfile
+++ b/kubernetes-monitoring/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:latest
+
+COPY nginx.conf /etc/nginx/nginx.conf
+
+RUN echo "Hello from Custom Nginx" > /usr/share/nginx/html/index.html

--- a/kubernetes-monitoring/app-deployment.yaml
+++ b/kubernetes-monitoring/app-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: homework-nginx-svc
+  namespace: default
+  labels:
+    app: homework-nginx
+spec:
+  selector:
+    app: homework-nginx
+  ports:
+    - name: web
+      port: 80
+      targetPort: 80
+    - name: metrics
+      port: 9113
+      targetPort: 9113
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: homework-nginx-deployment
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: homework-nginx
+  template:
+    metadata:
+      labels:
+        app: homework-nginx
+    spec:
+      containers:
+        - name: nginx
+          image: dvoryankin/nginx-with-metrics:v1.0
+          ports:
+            - containerPort: 80
+              name: web
+
+        - name: nginx-exporter
+          image: nginx/nginx-prometheus-exporter:0.11.0
+          args:
+            - "-nginx.scrape-uri=http://localhost/stub_status"
+          ports:
+            - containerPort: 9113
+              name: metrics

--- a/kubernetes-monitoring/app-servicemonitor.yaml
+++ b/kubernetes-monitoring/app-servicemonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: homework-nginx-sm
+  namespace: default
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: homework-nginx
+  endpoints:
+    - port: metrics
+      interval: 15s

--- a/kubernetes-monitoring/nginx.conf
+++ b/kubernetes-monitoring/nginx.conf
@@ -1,0 +1,38 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log notice;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+    keepalive_timeout 65;
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            root /usr/share/nginx/html;
+            index index.html index.htm;
+        }
+
+        location /stub_status {
+            stub_status;
+            allow 127.0.0.1;
+            deny all;
+        }
+    }
+}


### PR DESCRIPTION
      
# Выполнено ДЗ № 8 - Мониторинг компонентов кластера и приложений

- [x] Основное ДЗ (Кастомный образ Nginx, Prometheus Operator, ServiceMonitor)

## В процессе сделано:
- **Кастомный образ Nginx:**
    - Подготовлен `Dockerfile` и `nginx.conf` для создания образа Nginx с включенным модулем `stub_status` на эндпоинте `/stub_status`.
    - Образ был собран и загружен в репозиторий `dvoryankin/nginx-with-metrics:v1.0`.
- **Prometheus Operator:**
    - В кластер установлен стек мониторинга `kube-prometheus-stack` с помощью Helm в namespace `monitoring`.
- **Приложение:**
    - Создан `app-deployment.yaml`, который разворачивает `Deployment` для нашего приложения.
    - В Поде используется **sidecar-паттерн**: основной контейнер с кастомным Nginx и контейнер с `nginx-prometheus-exporter`.
    - Создан `Service` `homework-nginx-svc` с двумя портами: `web` (80) для трафика и `metrics` (9113) для Prometheus.
- **Сбор метрик:**
    - Создан `app-servicemonitor.yaml`, который описывает `ServiceMonitor` `homework-nginx-sm`.
    - `ServiceMonitor` настроен на поиск сервисов с меткой `app: homework-nginx` и сбор метрик с порта `metrics`.
    - Добавлена необходимая метка `release: prometheus` для обнаружения `ServiceMonitor`'а Прометеусом.

## Как запустить проект:
1.  Собрать и опубликовать кастомный Docker-образ (или загрузить в Minikube `minikube image load ...`).
2.  Установить Prometheus Operator:
    `helm repo add prometheus-community https://prometheus-community.github.io/helm-charts`
    `helm repo update`
    `kubectl create namespace monitoring`
    `helm install prometheus prometheus-community/kube-prometheus-stack --namespace monitoring`
    (Дождаться запуска всех подов в namespace `monitoring`).
3.  Применить манифесты приложения: `kubectl apply -f kubernetes-monitoring/`

## Как проверить работоспособность:
1.  Убедиться, что под `homework-nginx-deployment-...` запущен и `READY 2/2`: `kubectl get pods -n default`.
2.  Пробросить порт до Prometheus UI: `kubectl port-forward -n monitoring svc/prometheus-kube-prometheus-prometheus 9090:9090`.
3.  Открыть `http://localhost:9090` в браузере, перейти в `Status -> Targets`. Найти цель `serviceMonitor/default/homework-nginx-sm/0` и убедиться, что ее статус `UP`.
4.  На главной странице Prometheus выполнить запрос, например, `nginx_connections_active`, и убедиться, что метрика собирается. Можно пробросить порт до nginx kubectl port-forward svc/homework-nginx-svc 8888:80, сделать несколько курлов curl http://localhost:8888/ и посмотреть, что метрика растёт.

## PR checklist:
 - [x] Выставлен label с темой домашнего задания.
 - [x] PR не будет смерджен самостоятельно.

    