### PR TITLE
fear(homework) implement HashiCorp Vault with Consul backend and Exte…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ homework-cd-config.yaml
 # Helm / Helmfile
 charts/*.tgz
 .helmfile-work/
+
+vault-init.json
+*.token

--- a/kubernetes-vault/consul/values-bootstrap.yaml
+++ b/kubernetes-vault/consul/values-bootstrap.yaml
@@ -1,0 +1,25 @@
+global:
+  name: consul
+  datacenter: dc1
+
+server:
+  replicas: 3
+  bootstrapExpect: 3
+  extraConfig: |
+    {"retry_join": ["provider=k8s label_selector=\"app=consul,component=server\" namespace=consul"]}
+  disruptionBudget:
+    enabled: true
+  nodeSelector: |
+    node-role: "infra"
+  tolerations: |
+    - key: "node-role"
+      operator: "Equal"
+      value: "infra"
+      effect: "NoSchedule"
+
+client:
+  enabled: false
+ui:
+  enabled: true
+connectInject:
+  enabled: false

--- a/kubernetes-vault/consul/values-ha
+++ b/kubernetes-vault/consul/values-ha
@@ -1,0 +1,23 @@
+global:
+  name: consul
+  datacenter: dc1
+
+server:
+  replicas: 2
+  bootstrapExpect: 2
+  extraConfig: |
+    {"retry_join": ["provider=k8s label_selector=\"app=consul,component=server\" namespace=consul"]}
+  disruptionBudget:
+    enabled: true
+  tolerations: |
+    - key: "node-role"
+      operator: "Equal"
+      value: "infra"
+      effect: "NoSchedule"
+
+client:
+  enabled: false
+ui:
+  enabled: true
+connectInject:
+  enabled: false

--- a/kubernetes-vault/external-secrets/externalsecret.yaml
+++ b/kubernetes-vault/external-secrets/externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: otus-cred
+  namespace: vault
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: vault-otus
+    kind: SecretStore
+  target:
+    name: otus-cred
+    creationPolicy: Owner
+  data:
+    - secretKey: username
+      remoteRef:
+        key: cred
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: cred
+        property: password

--- a/kubernetes-vault/external-secrets/rbac.yaml
+++ b/kubernetes-vault/external-secrets/rbac.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: eso-k8s-auth
+  namespace: vault
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: eso-k8s-auth
+  namespace: vault
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: vault
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: eso-k8s-auth

--- a/kubernetes-vault/external-secrets/secretstore.yaml
+++ b/kubernetes-vault/external-secrets/secretstore.yaml
@@ -1,0 +1,17 @@
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: vault-otus
+  namespace: vault
+spec:
+  provider:
+    vault:
+      server: "http://vault.vault.svc.cluster.local:8200"
+      path: "otus"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "otus"
+          serviceAccountRef:
+            name: vault-auth

--- a/kubernetes-vault/manifests/vault-auth.yaml
+++ b/kubernetes-vault/manifests/vault-auth.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-auth
+  namespace: vault
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - kind: ServiceAccount
+    name: vault-auth
+    namespace: vault

--- a/kubernetes-vault/policy/otus-policy.hcl
+++ b/kubernetes-vault/policy/otus-policy.hcl
@@ -1,0 +1,2 @@
+path "otus/data/cred"     { capabilities = ["read"] }
+path "otus/metadata/cred" { capabilities = ["read","list"] }

--- a/kubernetes-vault/vault/values.yaml
+++ b/kubernetes-vault/vault/values.yaml
@@ -1,0 +1,28 @@
+server:
+  ha:
+    enabled: true
+  dataStorage:
+    enabled: false
+
+  extraConfig: |
+    listener "tcp" {
+      address         = "0.0.0.0:8200"
+      cluster_address = "0.0.0.0:8201"
+      tls_disable     = 1
+    }
+    storage "consul" {
+      address = "consul-server.consul.svc:8500"
+      path    = "vault/"
+    }
+    ui = true
+
+  nodeSelector:
+    node-role: "infra"
+  tolerations:
+    - key: "node-role"
+      operator: "Equal"
+      value: "infra"
+      effect: "NoSchedule"
+
+ui:
+  enabled: true


### PR DESCRIPTION
# Выполнено ДЗ № 11 — Хранилище секретов для приложения (Vault + ESO)

- [x] Основное ДЗ (Vault в HA с backend=Consul, Kubernetes-auth, KV, External Secrets)

## В процессе сделано

- **Инфраструктура Yandex Cloud:** Подготовлен кластер Managed Kubernetes с 3 нодами, что позволило развернуть отказоустойчивые конфигурации.
- **Consul (namespace `consul`):**
  - Установлен через Helm-чарт HashiCorp в HA-режиме с 3 репликами сервера.
  - Используется как надежный `backend` для хранения данных Vault.
- **Vault (namespace `vault`):**
  - Установлен через Helm-чарт HashiCorp в HA-режиме с 3 репликами.
  - Сконфигурирован для использования Consul в качестве `storage backend`.
  - Выполнены процедуры инициализации (`init`) и распечатывания (`unseal`) для активации кластера Vault.
  - Включен движок секретов `kv` (версии 2) на пути `otus/`.
  - Создан секрет `otus/cred` с парами `username=otus` и `password=asajkjkahs`.
  - Настроен метод аутентификации `kubernetes` для интеграции с кластером.
  - Создана политика `otus-policy`, дающая права на чтение секрета `otus/cred`.
  - Создана роль `otus`, которая связывает ServiceAccount `vault-auth` с политикой `otus-policy`.
- **External Secrets Operator (namespace `vault`):**
  - Установлен в кластер с помощью Helm-чарта.
  - Создан `SecretStore` `vault-otus`, описывающий подключение к Vault с использованием Kubernetes-аутентификации и роли `otus`.
  - Создан `ExternalSecret` `otus-cred`, который синхронизирует данные из `otus/cred` в Vault в нативный Kubernetes `Secret` с именем `otus-cred`.

## Структура репозитория
- Файлы конфигурации (`values.yaml`) для Consul и Vault разделены для удобства.
- Манифесты для RBAC, политик и ресурсов External Secrets Operator организованы в соответствующие директории.
- Сгенерированные секреты (`vault-init.json`, ключи, токены) исключены из репозитория через `.gitignore`.

## Как запустить проект (в окружении Yandex Cloud с 3+ нодами)
1.  **Установить Consul:**
    - `helm repo add hashicorp https://helm.releases.hashicorp.com`
    - `kubectl create ns consul`
    - `helm install consul hashicorp/consul -n consul -f kubernetes-vault/consul/values-ha.yaml` (используя HA-конфигурацию на 3 реплики).
2.  **Установить Vault:**
    - `kubectl create ns vault`
    - `helm install vault hashicorp/vault -n vault -f kubernetes-vault/vault/values.yaml`
3.  **Инициализировать и распечатать Vault:**
    - `kubectl exec -it vault-0 -n vault -- vault operator init > vault-init.json`
    - Распечатать все 3 пода Vault, используя ключи из `vault-init.json`.
    - Войти в Vault, используя root-токен: `export VAULT_TOKEN=...` и `export VAULT_ADDR=...` (через `port-forward`).
4.  **Настроить Vault и интеграцию с Kubernetes:**
    - Включить KV-хранилище, создать секрет и политику (`otus-policy.hcl`).
    - Применить `vault-auth.yaml` для создания SA.
    - Настроить auth-метод Kubernetes и создать роль `otus` в Vault.
5.  **Установить и настроить External Secrets Operator:**
    - `helm repo add external-secrets https://charts.external-secrets.io`
    - `helm install external-secrets external-secrets/external-secrets -n vault --set installCRDs=true`
    - `kubectl apply -f kubernetes-vault/external-secrets/secretstore.yaml`
    - `kubectl apply -f kubernetes-vault/external-secrets/externalsecret.yaml`

## Как проверить работоспособность
- **Проверка HA-кластера Consul:**
  `kubectl -n consul exec -ti consul-server-0 -- consul operator raft list-peers` (ожидается 1 лидер и 2 фолловера).
- **Проверка статуса Vault:**
  `vault status` (ожидается `HA Enabled: true`, `Sealed: false`).
- **Проверка работы External Secrets Operator:**
  `kubectl -n vault describe secretstore vault-otus` (статус должен быть `Ready`).
  `kubectl -n vault describe externalsecret otus-cred` (статус должен быть `SecretSynced`).
- **Финальная проверка созданного секрета:**
  `kubectl -n vault get secret otus-cred -o jsonpath='{.data.password}' | base64 -d ; echo`
  (Ожидаемый результат: `asajkjkahs`).

## PR checklist
 - [x] Приложены все необходимые `values.yaml` и манифесты, организованные по директориям.
 - [x] Приложены команды установки для Consul и Vault.
 - [x] PR не будет смерджен самостоятельно.