### PR TITLE
fear(homework): install Yandex S3 CSI driver + demo PVC/Pod

### DIFF
--- a/kubernetes-csi/manifests/01-secret.yaml
+++ b/kubernetes-csi/manifests/01-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-s3-secret
+  namespace: kube-system
+type: Opaque
+stringData:
+  # из /tmp/s3-csi-keys.json
+  accessKeyID: ${S3_ACCESS_KEY_ID}
+  secretAccessKey: ${S3_SECRET_ACCESS_KEY}
+  # эндпоинт YC Object Storage
+  endpoint: https://storage.yandexcloud.net

--- a/kubernetes-csi/manifests/02-storageclass.yaml
+++ b/kubernetes-csi/manifests/02-storageclass.yaml
@@ -1,0 +1,17 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: yc-s3
+provisioner: ru.yandex.s3.csi
+parameters:
+  bucket: ${BUCKET}
+  mounter: geesefs
+  options: "--dir-mode=0777 --file-mode=0666"
+  # секреты для provisioner и для node-stage:
+  csi.storage.k8s.io/provisioner-secret-name: csi-s3-secret
+  csi.storage.k8s.io/provisioner-secret-namespace: kube-system
+  csi.storage.k8s.io/node-stage-secret-name: csi-s3-secret
+  csi.storage.k8s.io/node-stage-secret-namespace: kube-system
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: false

--- a/kubernetes-csi/manifests/03-pvc.yaml
+++ b/kubernetes-csi/manifests/03-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: s3-pvc
+  namespace: csi-demo
+spec:
+  accessModes: [ ReadWriteMany ]
+  storageClassName: yc-s3
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes-csi/manifests/04-pod.yaml
+++ b/kubernetes-csi/manifests/04-pod.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: csi-s3-demo
+  namespace: csi-demo
+spec:
+  tolerations:
+    - key: "node-role"
+      operator: "Equal"
+      value: "infra"
+      effect: "NoSchedule"
+  containers:
+  - name: app
+    image: nginx:1.25
+    ports:
+      - containerPort: 80
+    volumeMounts:
+      - name: data
+        mountPath: /usr/share/nginx/html
+  initContainers:
+  - name: init
+    image: busybox:1.36
+    command: ["sh","-lc","echo 'Hello from S3 CSI!' > /mnt/index.html"]
+    volumeMounts:
+      - name: data
+        mountPath: /mnt
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: s3-pvc


### PR DESCRIPTION
# Выполнено ДЗ № 12 — Установка и использование CSI-драйвера

- [x] Основное ДЗ (установка CSI-драйвера для Yandex S3, создание SC/PVC/Pod, проверка чтения/записи)

## В процессе сделано

- **Инфраструктура Yandex Cloud:**
    - Подготовлен кластер Managed Kubernetes.
    - В Yandex S3 Object Storage создан бакет для использования в качестве `PersistentVolume`.
    - Создан сервисный аккаунт `s3-csi-sa` с ролью `storage.editor` и сгенерированы статические ключи доступа (Access Key / Secret Key).

- **Установка CSI-драйвера:**
    - С помощью Helm-чарта `yandex-s3/csi-s3` установлен CSI-драйвер в namespace `kube-system`.
    - **Важно:** После установки DaemonSet `csi-s3-node` был пропатчен для добавления `toleration`, позволяющего запускать поды-плагины на нодах с `taint: node-role=infra:NoSchedule`.

- **Настройка Kubernetes ресурсов:**
    - Создан `Secret` `csi-s3-secret` в `kube-system`, содержащий ключи доступа к S3. Манифест является шаблоном и применяется через `envsubst` для безопасности.
    - Создан `StorageClass` `yc-s3`, который использует `ru.yandex.s3.csi` в качестве `provisioner` и ссылается на `csi-s3-secret` для аутентификации. В качестве монтировщика используется `geesefs`.
    - В отдельном namespace `csi-demo` создан `PersistentVolumeClaim` `s3-pvc`, запрашивающий 1Gi хранилища у `StorageClass` `yc-s3` с режимом доступа `ReadWriteMany`.
    - Создан тестовый `Pod` `csi-s3-demo` с `init-container`, который записывает файл `index.html` в смонтированный PVC, и основным контейнером `nginx`, который читает и может отдавать этот файл.

## Как запустить проект

1.  **Подготовить Yandex Cloud:** Создать S3-бакет и сервисный аккаунт с ключами доступа. Экспортировать переменные окружения:
    ```bash
    export BUCKET=<имя_вашего_бакета>
    export S3_ACCESS_KEY_ID=<ваш_access_key>
    export S3_SECRET_ACCESS_KEY=<ваш_secret_key>
    ```
2.  **Установить CSI-драйвер:**
    ```bash
    helm repo add yandex-s3 https://yandex-cloud.github.io/k8s-csi-s3/charts && helm repo update
    helm install csi-s3 yandex-s3/csi-s3 -n kube-system --create-namespace
    ```
3.  **Пропатчить DaemonSet драйвера (если в кластере есть ноды с `taint`):**
    ```bash
    kubectl -n kube-system patch ds csi-s3-node --type=merge \
      -p '{"spec":{"template":{"spec":{"tolerations":[{"key":"node-role","operator":"Equal","value":"infra","effect":"NoSchedule"}]}}}}'
    ```
4.  **Развернуть приложение:**
    ```bash
    kubectl create namespace csi-demo
    # Применяем секрет с подстановкой переменных
    envsubst < kubernetes-csi/01-secret.yaml | kubectl apply -f -
    # Применяем StorageClass с подстановкой имени бакета
    envsubst < kubernetes-csi/02-storageclass.yaml | kubectl apply -f -
    # Применяем PVC и Pod
    kubectl apply -f kubernetes-csi/03-pvc.yaml
    kubectl apply -f kubernetes-csi/04-pod.yaml
    ```

## Как проверить работоспособность

1.  **Проверить, что поды CSI-драйвера запущены на всех нодах:**
    `kubectl get pods -n kube-system -l app=csi-s3-node -o wide`
2.  **Проверить, что PVC успешно привязался к хранилищу:**
    `kubectl get pvc s3-pvc -n csi-demo` (ожидается статус `Bound`).
3.  **Проверить, что тестовый под запустился и может читать/писать в том:**
    `kubectl get pod csi-s3-demo -n csi-demo` (ожидается статус `Running`).
    `kubectl exec -it csi-s3-demo -n csi-demo -- cat /usr/share/nginx/html/index.html`
    (Ожидаемый результат: `Hello from S3 CSI!`).
4.  **(Опционально) Проверить, что файл появился в S3-бакете** через веб-консоль Yandex Cloud.

## PR checklist
- [x] Приложены манифесты `01-secret.yaml` (как шаблон), `02-storageclass.yaml`, `03-pvc.yaml`, `04-pod.yaml`.
- [x] Описание шагов по настройке облака и развертыванию включено в описание PR.
- [x] PR не будет смерджен самостоятельно.